### PR TITLE
Fix unneccessary use of template keyword

### DIFF
--- a/vcg/complex/algorithms/update/selection.h
+++ b/vcg/complex/algorithms/update/selection.h
@@ -106,7 +106,7 @@ public:
     fsHandle fsH = fsV.back();
     tsHandle tsH = tsV.back();
 
-    if(! (Allocator<ComputeMeshType>::template IsValidHandle(*_m, vsH))) return false;
+    if(!Allocator<ComputeMeshType>::IsValidHandle(*_m, vsH)) return false;
 
     for(auto vi = _m->vert.begin(); vi != _m->vert.end(); ++vi)
       if( !(*vi).IsD() )


### PR DESCRIPTION
When attempting to build openMVS on macOS 15.6, I received the following compiler error:
```
/Users/REDACTED/include/vcg/vcg/complex/algorithms/update/selection.h:109:48: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
  109 |     if(! (Allocator<ComputeMeshType>::template IsValidHandle(*_m, vsH))) return false;
      |                                                ^
In file included from /Users/REDACTED/build/openMVS-prefix/src/openMVS/libs/MVS/Mesh.cpp:51:
...
```

I don't know why this is suddenly an error in Apple Clang, but this removes the unnecessary use of `template`.